### PR TITLE
Specify Swift version

### DIFF
--- a/ios/system_setting.podspec
+++ b/ios/system_setting.podspec
@@ -17,5 +17,6 @@ Flutter plugin for jumping to system settings.
   s.dependency 'Flutter'
 
   s.ios.deployment_target = '8.0'
+  s.swift_version = '4.0'
 end
 


### PR DESCRIPTION
`pod install` fails:

```
Installing system_setting 0.1.1
[!] Unable to determine Swift version for the following pods:

- `system_setting` does not specify a Swift version and none of the targets (`Runner`) integrating it have the `SWIFT_VERSION` attribute set. Please contact the author or set the `SWIFT_VERSION` attribute in at least one of the targets that integrate this pod.
```

I use pod version 1.6.0.
